### PR TITLE
Adds sorting an offset file by timestamp.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ license = "AGPL-3.0"
 buffered_offset_reader = "0.3"
 clap = "~2.32.0"
 flumedb = { git = "https://github.com/sunrise-choir/flumedb-rs" }
+rayon = "1.2.0"
 serde_json = "1.0"
 termion = "1"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ FLAGS:
 SUBCOMMANDS:
     extract    Copy the feed for a single id into a separate file.
     help       Prints this message or the help of the given subcommand(s)
+    sort       Copy all the feeds and sort by asserted time
     view       View a flumedb offset log file
 ```
 
@@ -47,6 +48,26 @@ FLAGS:
 
 OPTIONS:
     -f, --feed <id>    feed (user) id (eg. "@N/vWpVVdD..."
+    -i, --in <in>      source offset log file
+    -o, --out <out>    destination path
+```
+
+
+- `sort` all the messages in an offset file by `assertedTimestamp`
+```
+feedrick sort --in ~/.ssb/flume/log.offset --out /tmp/sorted.offset 
+```
+
+```
+USAGE:
+    feedrick sort [FLAGS] --in <in> --out <out>
+
+FLAGS:
+    -h, --help         Prints help information
+        --overwrite    Overwrite output file, if it exists.
+    -V, --version      Prints version information
+
+OPTIONS:
     -i, --in <in>      source offset log file
     -o, --out <out>    destination path
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,57 +1,97 @@
-use std::fs::{OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{self, stdin, stdout, Write};
 use std::path::Path;
 
-use clap::{Arg, App, SubCommand};
+use rayon::prelude::*;
+use clap::{App, Arg, SubCommand};
 
 use flumedb::flume_log::{Error, FlumeLog};
-use flumedb::offset_log::{BidirIterator, OffsetLog, LogEntry};
+use flumedb::offset_log::{BidirIterator, LogEntry, OffsetLog};
 
-use serde_json::{Value, to_string_pretty};
+use serde_json::{to_string_pretty, Value};
 
+use termion::event::Key;
 use termion::input::TermRead;
 use termion::raw::IntoRawMode;
-use termion::event::Key;
-
 
 fn main() -> Result<(), Error> {
     let app_m = App::new("feedrick")
         .version("0.1")
         .author("Sunrise Choir (sunrisechoir.com)")
         .about("ssb flumedb offset log utilities")
-        .subcommand(SubCommand::with_name("extract")
-                    .about("Copy the feed for a single id into a separate file.")
-                    .arg(Arg::with_name("in")
-                         .long("in")
-                         .short("i")
-                         .required(true)
-                         .takes_value(true)
-                         .help("source offset log file"))
-                    .arg(Arg::with_name("out")
-                         .long("out")
-                         .short("o")
-                         .required(true)
-                         .takes_value(true)
-                         .help("destination path"))
-                    .arg(Arg::with_name("id")
-                         .long("feed")
-                         .short("f")
-                         .required(true)
-                         .takes_value(true)
-                         .help("feed (user) id (eg. \"@N/vWpVVdD...\""))
-                    .arg(Arg::with_name("overwrite")
-                         .long("overwrite")
-                         .help("Overwrite output file, if it exists."))
-                    .arg(Arg::with_name("invert")
-                         .long("invert")
-                         .help("Output a log file containing all feeds *but* the specified id."))
+        .subcommand(
+            SubCommand::with_name("sort")
+                .about("Copy all the feeds and sort by asserted time")
+                .arg(
+                    Arg::with_name("in")
+                        .long("in")
+                        .short("i")
+                        .required(true)
+                        .takes_value(true)
+                        .help("source offset log file"),
+                )
+                .arg(
+                    Arg::with_name("out")
+                        .long("out")
+                        .short("o")
+                        .required(true)
+                        .takes_value(true)
+                        .help("destination path"),
+                )
+                .arg(
+                    Arg::with_name("overwrite")
+                        .long("overwrite")
+                        .help("Overwrite output file, if it exists."),
+                ),
         )
-        .subcommand(SubCommand::with_name("view")
-                    .about("View a flumedb offset log file")
-                    .arg(Arg::with_name("FILE")
-                         .help("offset log file to view")
-                         .required(true)
-                         .index(1)))
+        .subcommand(
+            SubCommand::with_name("extract")
+                .about("Copy the feed for a single id into a separate file.")
+                .arg(
+                    Arg::with_name("in")
+                        .long("in")
+                        .short("i")
+                        .required(true)
+                        .takes_value(true)
+                        .help("source offset log file"),
+                )
+                .arg(
+                    Arg::with_name("out")
+                        .long("out")
+                        .short("o")
+                        .required(true)
+                        .takes_value(true)
+                        .help("destination path"),
+                )
+                .arg(
+                    Arg::with_name("id")
+                        .long("feed")
+                        .short("f")
+                        .required(true)
+                        .takes_value(true)
+                        .help("feed (user) id (eg. \"@N/vWpVVdD...\""),
+                )
+                .arg(
+                    Arg::with_name("overwrite")
+                        .long("overwrite")
+                        .help("Overwrite output file, if it exists."),
+                )
+                .arg(
+                    Arg::with_name("invert")
+                        .long("invert")
+                        .help("Output a log file containing all feeds *but* the specified id."),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("view")
+                .about("View a flumedb offset log file")
+                .arg(
+                    Arg::with_name("FILE")
+                        .help("offset log file to view")
+                        .required(true)
+                        .index(1),
+                ),
+        )
         .get_matches();
 
     match app_m.subcommand() {
@@ -91,14 +131,63 @@ fn main() -> Result<(), Error> {
             } else {
                 copy_log_entries_using_author(in_log, out_log, |id| id == feed_id)
             }
-        },
+        }
+        ("sort", Some(sub_m)) => {
+            let in_path = sub_m.value_of("in").unwrap();
+            let out_path = sub_m.value_of("out").unwrap();
+            let overwrite = sub_m.is_present("overwrite");
+
+            if !overwrite && Path::new(out_path).exists() {
+                eprintln!("Output path `{}` exists.", out_path);
+                eprintln!("Use `--overwrite` option to overwrite.");
+                return Ok(());
+            }
+
+            let file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&out_path)?;
+
+            let mut out_log = OffsetLog::<u32>::from_file(file)?;
+
+            let in_log = OffsetLog::<u32>::open_read_only(in_path)?;
+            if in_log.end() == 0 {
+                eprintln!("Input offset log file is empty.");
+                return Ok(());
+            }
+
+            let mut entries = in_log
+                .iter()
+                .forward()
+                .collect::<Vec<_>>();
+
+            entries
+                .par_sort_unstable_by(|a, b| {
+                    let a_time = get_entry_timestamp(a);
+                    let b_time = get_entry_timestamp(b);
+                    a_time
+                        .partial_cmp(&b_time)
+                        .unwrap()
+                });
+
+
+            eprintln!(" from offset log at path:     {}", in_path);
+            eprintln!(" into new offset log at path: {}", out_path);
+
+            entries.iter().for_each(|entry|{
+                out_log.append(&entry.data).unwrap();
+            });
+
+            Ok(())
+        }
 
         ("view", Some(sub_m)) => {
             let path = sub_m.value_of("FILE").unwrap();
 
             let log = OffsetLog::<u32>::open_read_only(path)?;
             view_log(log)
-        },
+        }
         _ => {
             println!("{}", app_m.usage());
             Ok(())
@@ -107,17 +196,20 @@ fn main() -> Result<(), Error> {
 }
 
 // copy if author id matches predicate
-fn copy_log_entries_using_author<F>(in_log: OffsetLog<u32>, out_log: OffsetLog<u32>, should_write: F)
-                                    -> Result<(), Error>
+fn copy_log_entries_using_author<F>(
+    in_log: OffsetLog<u32>,
+    out_log: OffsetLog<u32>,
+    should_write: F,
+) -> Result<(), Error>
 where
     F: Fn(&str) -> bool,
 {
     copy_log_entries(in_log, out_log, |e| {
-        let v: Result<Value, serde_json::error::Error>
-            = serde_json::from_slice(&e.data);
+        let v: Result<Value, serde_json::error::Error> = serde_json::from_slice(&e.data);
 
         match v {
-            Ok(v) => v.get("value")
+            Ok(v) => v
+                .get("value")
                 .and_then(|v| v.get("author"))
                 .and_then(|v| v.as_str())
                 .map_or(false, |v| should_write(v)),
@@ -126,9 +218,11 @@ where
     })
 }
 
-
-fn copy_log_entries<F>(in_log: OffsetLog<u32>, mut out_log: OffsetLog<u32>, should_write: F)
-                        -> Result<(), Error>
+fn copy_log_entries<F>(
+    in_log: OffsetLog<u32>,
+    mut out_log: OffsetLog<u32>,
+    should_write: F,
+) -> Result<(), Error>
 where
     F: Fn(&LogEntry) -> bool,
 {
@@ -159,11 +253,11 @@ where
         }
 
         if should_write || (pct > prev_pct) {
-            write!(handle,
-                   "\rProgress: {}%\tCopied {} messages ({} bytes)",
-                   pct,
-                   count,
-                   bytes)?;
+            write!(
+                handle,
+                "\rProgress: {}%\tCopied {} messages ({} bytes)",
+                pct, count, bytes
+            )?;
             handle.flush()?;
             prev_pct = pct;
         }
@@ -177,54 +271,62 @@ fn view_log(log: OffsetLog<u32>) -> Result<(), Error> {
     let stdin = stdin();
     let mut stdout = stdout().into_raw_mode()?;
 
-    let mut iter = log.iter()
-        .map(|e| {
-            let v = serde_json::from_slice(&e.data).unwrap();
-            (e, v)
-        });
+    let mut iter = log.iter().map(|e| {
+        let v = serde_json::from_slice(&e.data).unwrap();
+        (e, v)
+    });
 
-    iter.next().map(|(e, v)| print_entry(e.offset, &v, &mut stdout));
+    iter.next()
+        .map(|(e, v)| print_entry(e.offset, &v, &mut stdout));
 
     for c in stdin.keys() {
         match c? {
-            Key::Char('q') |
-            Key::Ctrl('c') |
-            Key::Esc => {
+            Key::Char('q') | Key::Ctrl('c') | Key::Esc => {
                 break;
-            },
-            Key::Up |
-            Key::Left |
-            Key::Char('p') |
-            Key::Char('k') => {
+            }
+            Key::Up | Key::Left | Key::Char('p') | Key::Char('k') => {
                 iter.prev()
-                    .map(|(e, v)| print_entry(e.offset, &v, &mut stdout) )
+                    .map(|(e, v)| print_entry(e.offset, &v, &mut stdout))
                     .or_else(|| write!(stdout, "No record").ok());
-            },
-            Key::Down |
-            Key::Right |
-            Key::Char('n') |
-            Key::Char('j')=> {
+            }
+            Key::Down | Key::Right | Key::Char('n') | Key::Char('j') => {
                 iter.next()
-                    .map(|(e, v)| print_entry(e.offset, &v, &mut stdout) )
+                    .map(|(e, v)| print_entry(e.offset, &v, &mut stdout))
                     .or_else(|| write!(stdout, "No record").ok());
-            },
+            }
             Key::Char(c) => {
                 eprintln!("KEY: {}", c);
-            },
-            _ => {},
+            }
+            _ => {}
         }
     }
 
     Ok(())
 }
 
+fn get_entry_timestamp(e: &LogEntry) -> f64 {
+    let v: Result<Value, serde_json::error::Error> = serde_json::from_slice(&e.data);
+
+    match v {
+        Ok(v) => v
+            .get("value")
+            .and_then(|v| v.get("timestamp"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0),
+        Err(_) => 0.0,
+    }
+}
+
 fn print_entry<W: Write>(offset: u64, data: &serde_json::Value, mut stdout: &mut W) {
-    write!(stdout,
-           "{}{}Press `j` or `k` to show the next or previous entry. Press `q` to exit.{}Offset: {}",
-           termion::clear::All,
-           termion::cursor::Goto(1, 1),
-           termion::cursor::Goto(1, 2),
-           offset).unwrap();
+    write!(
+        stdout,
+        "{}{}Press `j` or `k` to show the next or previous entry. Press `q` to exit.{}Offset: {}",
+        termion::clear::All,
+        termion::cursor::Goto(1, 1),
+        termion::cursor::Goto(1, 2),
+        offset
+    )
+    .unwrap();
     print_lines(&to_string_pretty(&data).unwrap(), &mut stdout).unwrap();
     stdout.flush().unwrap();
 }


### PR DESCRIPTION
I'm experimenting with sorting an offset file by `assertedTimestamp`

It's useful because the go-ssb-server tends to sync one whole feed at a time. So the ordering of threads is broken when you do an initial sync.

I use Rayon's parallel sort as well which was delightfully easy to get going. 

I'm quite happy with the performance.

Running this:
```
time ./target/release/feedrick sort -i ~/.ssb/flume/log.offset -o sorted.offset
```

Gave this:
```
 from offset log at path:     /home/piet/.ssb/flume/log.offset
 into new offset log at path: sorted.offset
 sorted 567595 entries, writing out to new offset file
./target/release/feedrick sort -i ~/.ssb/flume/log.offset -o sorted.offset  2.83s user 1.66s system 100% cpu 4.444 total
```

4.4s is much better than my first go which sorted the entire log in memory without rayon. That took 120s.

I also ran a `cargo fmt` which has made the diff horrible. Soz.